### PR TITLE
Fix bug

### DIFF
--- a/frontend/src/components/profile/ProfileBasicInfo.js
+++ b/frontend/src/components/profile/ProfileBasicInfo.js
@@ -96,7 +96,9 @@ export const ProfileBasicInfo = ({profile, XPEvents}) => {
     }
 
     const currentDay = new Date();
-    const hasGainedXpToday = (currentDay.getDate() === (new Date(XPEvents.at(-1).date)).getDate() 
+    console.log(XPEvents)
+    const hasGainedXpToday = (XPEvents.length !== 0
+                                && currentDay.getDate() === (new Date(XPEvents.at(-1).date)).getDate() 
                                 && currentDay.getMonth() === (new Date(XPEvents.at(-1).date)).getMonth()
                                 && currentDay.getFullYear() === (new Date(XPEvents.at(-1).date)).getFullYear());
     const streak = computeStreak(XPEvents, hasGainedXpToday);


### PR DESCRIPTION
This PR fixes a bug where the page would break if the user didn't have any XP Events registered (new user).
We were assuming the user had atleast one `XP Event` a so the page broke because we were trying to access an index that didn't exist.